### PR TITLE
handle different pytest versions

### DIFF
--- a/pytest_blender/plugin.py
+++ b/pytest_blender/plugin.py
@@ -102,7 +102,10 @@ def pytest_configure(config):
     def handled_exit():
         # hide "Exit:" message shown by pytest on exit
         sys.stderr = io.StringIO()
-        pytest.exit("", returncode=proc.returncode)
+        if pytest.__version__.startswith('7'):
+            pytest.exit("Finish", returncode=proc.returncode)
+        else:
+            pytest.exit("", returncode=proc.returncode)
 
     def on_sigint(signum, frame):
         proc.send_signal(signum)

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ dev =
     flake8-print==4.0.0
     isort==5.9.1
     pre-commit==2.13.0
-    pytest==6.2.5
+    pytest==7.0.1
     yamllint==1.26.1
 lint =
     black==20.8b1
@@ -54,7 +54,7 @@ lint =
     isort==5.9.1
     yamllint==1.26.1
 test =
-    pytest==6.2.5
+    pytest==7.0.1
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Using the latest pytest==7.0.1, I got the following error:
```python
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============ 61 passed, 2 skipped, 11 warnings in 68.97s (0:01:08) =============
Error: Process completed with exit code 4.
```
In the latest pytest==7.0.1, the [pytest.exit()](https://docs.pytest.org/en/latest/reference/reference.html?highlight=exit#pytest.exit) function is different from [version 6](https://docs.pytest.org/en/6.2.x/reference.html?highlight=exit#pytest.exit). It needs a default value for ``reason``.
