### PR TITLE
Fix `pytest-blender` CLI outputting `None` on Windows

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.1
+current_version = 3.0.2
 
 [bumpversion:file:pytest_blender/__init__.py]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,11 +111,11 @@ jobs:
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
           $BLENDER_EXECUTABLE = get-content _blender-executable-path.txt
           echo "BLENDER_EXECUTABLE: $BLENDER_EXECUTABLE"
-          pytest-blender --blender-executable "$BLENDER_EXECUTABLE"
-          $PYTHON_BLENDER_EXECUTABLE = (pytest-blender --blender-executable "$BLENDER_EXECUTABLE")
-          echo "PYTHON_BLENDER_EXECUTABLE: $PYTHON_BLENDER_EXECUTABLE"
-          $PYTHON_BLENDER_EXECUTABLE -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
-          echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
+        # pytest-blender --blender-executable "$BLENDER_EXECUTABLE"
+        # $PYTHON_BLENDER_EXECUTABLE = (pytest-blender --blender-executable "$BLENDER_EXECUTABLE")
+        # echo "PYTHON_BLENDER_EXECUTABLE: $PYTHON_BLENDER_EXECUTABLE"
+        # $PYTHON_BLENDER_EXECUTABLE -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
+        # echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
       - name: Unit tests
         if: runner.os != 'Windows'
         run: BLENDER_EXECUTABLE="${{ steps.install-dependencies-unix.outputs.blender-executable }}" pytest -svv --strict-config --strict-markers tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
         if: runner.os != 'Windows'
         id: install-dependencies-unix
         run: |
+          set -x
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
           BLENDER_EXECUTABLE="$(< _blender-executable-path.txt)"
           echo "BLENDER_EXECUTABLE: $BLENDER_EXECUTABLE"
@@ -108,6 +109,7 @@ jobs:
         if: runner.os == 'Windows'
         id: install-dependencies-windows
         run: |
+          Set-PSDebug -Trace 1
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
           $BLENDER_EXECUTABLE = get-content _blender-executable-path.txt
           echo "BLENDER_EXECUTABLE: $BLENDER_EXECUTABLE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
           pytest-blender --blender-executable $(Get-Variable -Name $BLENDER_EXECUTABLE -ValueOnly)
           $PYTHON_BLENDER_EXECUTABLE = (pytest-blender --blender-executable "$(Get-Variable -Name $BLENDER_EXECUTABLE -ValueOnly)")
           echo "PYTHON_BLENDER_EXECUTABLE: $PYTHON_BLENDER_EXECUTABLE"
-          $PYTHON_BLENDER_EXECUTABLE -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
+          $(Get-Variable -Name $PYTHON_BLENDER_EXECUTABLE -ValueOnly) -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
           echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
       - name: Unit tests
         if: runner.os != 'Windows'
@@ -130,6 +130,9 @@ jobs:
         # Created empty pytest.ini file to avoid the reading of setup.cfg
         # because there is a problem with encoding on Windows, see:
         # https://github.com/pytest-dev/pytest/issues/4441
+        #
+        # Note that pytest.ini will always take precedence, even if empty, see:
+        # https://docs.pytest.org/en/7.1.x/reference/customize.html#finding-the-rootdir
         run: |
           New-Item -Path 'pytest.ini' -ItemType File
           pytest -svv -p no:pytest-blender -p pytester --strict-config --strict-markers tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,11 +115,11 @@ jobs:
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
           $BLENDER_EXECUTABLE = get-content _blender-executable-path.txt
           echo "BLENDER_EXECUTABLE: $BLENDER_EXECUTABLE"
-        # pytest-blender --blender-executable "$BLENDER_EXECUTABLE"
-        # $PYTHON_BLENDER_EXECUTABLE = (pytest-blender --blender-executable "$BLENDER_EXECUTABLE")
-        # echo "PYTHON_BLENDER_EXECUTABLE: $PYTHON_BLENDER_EXECUTABLE"
-        # $PYTHON_BLENDER_EXECUTABLE -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
-        # echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
+          pytest-blender --blender-executable $(Get-Variable -Name $BLENDER_EXECUTABLE -ValueOnly)
+          $PYTHON_BLENDER_EXECUTABLE = (pytest-blender --blender-executable "$(Get-Variable -Name $BLENDER_EXECUTABLE -ValueOnly)")
+          echo "PYTHON_BLENDER_EXECUTABLE: $PYTHON_BLENDER_EXECUTABLE"
+          $PYTHON_BLENDER_EXECUTABLE -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
+          echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
       - name: Unit tests
         if: runner.os != 'Windows'
         run: pytest -svv --strict-config --strict-markers tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,7 @@ jobs:
         id: download-blender
         run: |
           python -m pip install --upgrade blender-downloader
-          echo "$(blender-downloader \
-          ${{ matrix.blender-version }} --extract --remove-compressed \
-          --print-blender-executable --quiet)" > _blender-executable-path.txt
+          echo "$(blender-downloader ${{ matrix.blender-version }} --extract --remove-compressed --print-blender-executable --quiet)" > _blender-executable-path.txt
       - name: Install dependencies
         id: install-dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           # Test against Pytest v7
           - platform: ubuntu-latest
-            pytest-version: '7.0.1'
+            pytest-version: '7.1.2'
             blender-version: '3.1.1'
             python-version: '3.10'
           # Test against Pytest v6
@@ -29,7 +29,7 @@ jobs:
             python-version: '3.9'
           # Test in MacOS (Py310)
           - platform: macos-latest
-            pytest-version: '7.0.1'
+            pytest-version: '7.1.2'
             blender-version: '3.1.2'
             python-version: '3.10'
           # Test in MacOS (Py39)
@@ -39,13 +39,18 @@ jobs:
             python-version: '3.9'
           # Test previous Blender versions
           - platform: ubuntu-latest
-            pytest-version: '7.0.1'
+            pytest-version: '7.1.2'
             blender-version: '2.83.9'
             python-version: '3.8'
           - platform: ubuntu-latest
-            pytest-version: '7.0.1'
+            pytest-version: '7.1.2'
             blender-version: '2.82'
             python-version: '3.7'
+          # Test in Windows
+          - platform: windows-latest
+            pytest-version: '7.1.2'
+            blender-version: '3.1.2'
+            python-version: '3.8'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python v${{ matrix.python-version }}
@@ -75,6 +80,7 @@ jobs:
         run: |
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
           blender_executable="$(< _blender-executable-path.txt tr -d '\n')"
+          pytest-blender --blender-executable $blender_executable
           python_blender_executable="$(pytest-blender --blender-executable $blender_executable)"
           $python_blender_executable -m ensurepip
           $python_blender_executable -m pip install pytest==${{ matrix.pytest-version }} pytest-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,10 +115,10 @@ jobs:
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
           $BLENDER_EXECUTABLE = get-content _blender-executable-path.txt
           echo "BLENDER_EXECUTABLE: $BLENDER_EXECUTABLE"
-          pytest-blender --blender-executable $(Get-Variable -Name BLENDER_EXECUTABLE)
-          $PYTHON_BLENDER_EXECUTABLE = pytest-blender --blender-executable "$(Get-Variable -Name BLENDER_EXECUTABLE)"
+          pytest-blender --blender-executable $(Get-Variable -Name BLENDER_EXECUTABLE -ValueOnly)
+          $PYTHON_BLENDER_EXECUTABLE = pytest-blender --blender-executable "$(Get-Variable -Name BLENDER_EXECUTABLE -ValueOnly)"
           echo "PYTHON_BLENDER_EXECUTABLE: $PYTHON_BLENDER_EXECUTABLE"
-          Invoke-Expression $PYTHON_BLENDER_EXECUTABLE -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
+          Invoke-Expression "$PYTHON_BLENDER_EXECUTABLE -m pip install pytest==${{ matrix.pytest-version }} pytest-cov"
           echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
       - name: Unit tests
         if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
           steps.cache-blender.outputs.cache-hit != 'true' &&
           runner.os != 'Windows'
         run: |
+          set -x
           python -m pip install --upgrade blender-downloader
           python -m pip list
           printf "%s" "$(blender-downloader ${{ matrix.blender-version }} --extract --remove-compressed --print-blender-executable --quiet)" > _blender-executable-path.txt
@@ -85,6 +86,7 @@ jobs:
           steps.cache-blender.outputs.cache-hit != 'true' &&
           runner.os == 'Windows'
         run: |
+          Set-PSDebug -Trace 2
           python -m pip install --upgrade blender-downloader
           python -m pip list
           blender-downloader ${{ matrix.blender-version }} --extract --remove-compressed --print-blender-executable --quiet | Out-File -FilePath _blender-executable-path.txt
@@ -109,7 +111,7 @@ jobs:
         if: runner.os == 'Windows'
         id: install-dependencies-windows
         run: |
-          Set-PSDebug -Trace 1
+          Set-PSDebug -Trace 2
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
           $BLENDER_EXECUTABLE = get-content _blender-executable-path.txt
           echo "BLENDER_EXECUTABLE: $BLENDER_EXECUTABLE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,8 @@ jobs:
         id: install-dependencies
         run: |
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
+          pytest-blender
           blender_executable="$(< _blender-executable-path.txt tr -d '\n')"
-          pytest-blender --blender-executable $blender_executable
           python_blender_executable="$(pytest-blender --blender-executable $blender_executable)"
           $python_blender_executable -m ensurepip
           $python_blender_executable -m pip install pytest==${{ matrix.pytest-version }} pytest-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade PIP
-        run: python -m pip installplatform --upgrade pip
+        run: python -m pip install --upgrade pip
       - name: Cache Blender ${{ matrix.blender-version }}
         uses: actions/cache@v3
         id: cache-blender

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,11 +115,11 @@ jobs:
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
           $BLENDER_EXECUTABLE = get-content _blender-executable-path.txt
           echo "BLENDER_EXECUTABLE: $BLENDER_EXECUTABLE"
-          pytest-blender --blender-executable $(Get-Variable -Name BLENDER_EXECUTABLE -ValueOnly)
-          $PYTHON_BLENDER_EXECUTABLE = (pytest-blender --blender-executable "$(Get-Variable -Name BLENDER_EXECUTABLE -ValueOnly)")
+          pytest-blender --blender-executable $(Get-Variable -Name BLENDER_EXECUTABLE)
+          $PYTHON_BLENDER_EXECUTABLE = pytest-blender --blender-executable "$(Get-Variable -Name BLENDER_EXECUTABLE)"
           echo "PYTHON_BLENDER_EXECUTABLE: $PYTHON_BLENDER_EXECUTABLE"
-        #$(Get-Variable -Name $PYTBLENDER_EXECUTABLEHON_BLENDER_EXECUTABLE -ValueOnly) -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
-        #echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
+          $(Get-Variable -Name PYTHON_BLENDER_EXECUTABLE) -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
+          echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
       - name: Unit tests
         if: runner.os != 'Windows'
         run: pytest -svv --strict-config --strict-markers tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,26 +92,28 @@ jobs:
       # Install dependencies on Unix-based systems
       - name: Install dependencies
         if: runner.os != 'Windows'
+        id: install-dependencies
         run: |
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
           BLENDER_EXECUTABLE="$(< _blender-executable-path.txt)"
-          echo "$BLENDER_EXECUTABLE"
+          echo "BLENDER_EXECUTABLE: $BLENDER_EXECUTABLE"
           pytest-blender --blender-executable "$BLENDER_EXECUTABLE"
           PYTHON_BLENDER_EXECUTABLE="$(pytest-blender --blender-executable $BLENDER_EXECUTABLE)"
-          echo "$PYTHON_BLENDER_EXECUTABLE"
+          echo "PYTHON_BLENDER_EXECUTABLE: $PYTHON_BLENDER_EXECUTABLE"
           $PYTHON_BLENDER_EXECUTABLE -m ensurepip
           $PYTHON_BLENDER_EXECUTABLE -m pip install pytest==${{ matrix.pytest-version }}
           echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
       # Install dependencies on Windows
       - name: Install dependencies
         if: runner.os == 'Windows'
+        id: install-dependencies
         run: |
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
-          $BLENDER_EXECUTABLE = Get-Content _blender-executable-path.txt | Out-String
-          echo "$BLENDER_EXECUTABLE"
+          $BLENDER_EXECUTABLE = get-content _blender-executable-path.txt
+          echo "BLENDER_EXECUTABLE: $BLENDER_EXECUTABLE"
           pytest-blender --blender-executable "$BLENDER_EXECUTABLE"
           $PYTHON_BLENDER_EXECUTABLE = (pytest-blender --blender-executable "$BLENDER_EXECUTABLE")
-          echo "$PYTHON_BLENDER_EXECUTABLE"
+          echo "PYTHON_BLENDER_EXECUTABLE: $PYTHON_BLENDER_EXECUTABLE"
           $PYTHON_BLENDER_EXECUTABLE -m pip install pytest==${{ matrix.pytest-version }}
           echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
       - name: Unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Test in Windows
+          - platform: windows-latest
+            pytest-version: '7.1.2'
+            blender-version: '3.1.2'
+            # Using 3.10 in Windows due to PIP encoding errors:
+            # https://github.com/pypa/pip/issues/11066
+            python-version: '3.10'
+          # Test previous Blender versions
+          - platform: ubuntu-latest
+            pytest-version: '7.1.2'
+            blender-version: '2.83.9'
+            python-version: '3.8'
+          - platform: ubuntu-latest
+            pytest-version: '7.1.2'
+            blender-version: '2.82'
+            python-version: '3.7'
           # Test against Pytest v7
           - platform: ubuntu-latest
             pytest-version: '7.1.2'
@@ -37,22 +53,6 @@ jobs:
             pytest-version: '6.2.5'
             blender-version: '2.93.9'
             python-version: '3.9'
-          # Test previous Blender versions
-          - platform: ubuntu-latest
-            pytest-version: '7.1.2'
-            blender-version: '2.83.9'
-            python-version: '3.8'
-          - platform: ubuntu-latest
-            pytest-version: '7.1.2'
-            blender-version: '2.82'
-            python-version: '3.7'
-          # Test in Windows
-          - platform: windows-latest
-            pytest-version: '7.1.2'
-            blender-version: '3.1.2'
-            # Using 3.10 in Windows due to PIP encoding errors:
-            # https://github.com/pypa/pip/issues/11066
-            python-version: '3.10'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python v${{ matrix.python-version }}
@@ -101,7 +101,7 @@ jobs:
           PYTHON_BLENDER_EXECUTABLE="$(pytest-blender --blender-executable $BLENDER_EXECUTABLE)"
           echo "PYTHON_BLENDER_EXECUTABLE: $PYTHON_BLENDER_EXECUTABLE"
           $PYTHON_BLENDER_EXECUTABLE -m ensurepip
-          $PYTHON_BLENDER_EXECUTABLE -m pip install pytest==${{ matrix.pytest-version }}
+          $PYTHON_BLENDER_EXECUTABLE -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
           echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
       # Install dependencies on Windows
       - name: Install dependencies
@@ -114,7 +114,7 @@ jobs:
           pytest-blender --blender-executable "$BLENDER_EXECUTABLE"
           $PYTHON_BLENDER_EXECUTABLE = (pytest-blender --blender-executable "$BLENDER_EXECUTABLE")
           echo "PYTHON_BLENDER_EXECUTABLE: $PYTHON_BLENDER_EXECUTABLE"
-          $PYTHON_BLENDER_EXECUTABLE -m pip install pytest==${{ matrix.pytest-version }}
+          $PYTHON_BLENDER_EXECUTABLE -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
           echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
       - name: Unit tests
         if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
             blender-*
             _blender-executable-path.txt
           key: ${{ runner.os }}-${{ matrix.blender-version }}
-      # Download Blender in Linux and MacOS
+      # Download Blender on Linux and MacOS
       - name: Download Blender ${{ matrix.blender-version }}
         if: |
           steps.cache-blender.outputs.cache-hit != 'true' &&
@@ -81,7 +81,7 @@ jobs:
           --extract --remove-compressed --print-blender-executable --quiet)" \
           > _blender-executable-path.txt
           cat _blender-executable-path.txt
-      # Download Blender in Windows
+      # Download Blender on Windows
       - name: Download Blender ${{ matrix.blender-version }}
         if: |
           steps.cache-blender.outputs.cache-hit != 'true' &&
@@ -108,11 +108,18 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
-          pytest-blender D:\a\pytest-blender\pytest-blender\blender-3.1.2-windows-x64\blender.exe
+          pytest-blender --blender-executable D:\a\pytest-blender\pytest-blender\blender-3.1.2-windows-x64\blender.exe
+
       - name: Unit tests
+        if: runner.os != 'Windows'
         run: BLENDER_EXECUTABLE="${{ steps.install-dependencies.outputs.blender-executable }}" pytest -svv --strict-config --strict-markers tests
+      - name: Unit tests
+        if: runner.os == 'Windows'
+        run: pwsh -Command { $env:BLENDER_EXECUTABLE="${{ steps.install-dependencies.outputs.blender-executable }}"; pytest -svv --strict-config --strict-markers tests }
       - name: Integration tests
+        if: runner.os != 'Windows'
         run: BLENDER_EXECUTABLE="${{ steps.install-dependencies.outputs.blender-executable }}" sh tests/integration.sh
+      # TODO: integration tests on Windows?
       - run: exit 1
 
   build-sdist:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,10 +115,10 @@ jobs:
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
           $BLENDER_EXECUTABLE = get-content _blender-executable-path.txt
           echo "BLENDER_EXECUTABLE: $BLENDER_EXECUTABLE"
-          pytest-blender --blender-executable $(Get-Variable -Name $BLENDER_EXECUTABLE -ValueOnly)
-          $PYTHON_BLENDER_EXECUTABLE = (pytest-blender --blender-executable "$(Get-Variable -Name $BLENDER_EXECUTABLE -ValueOnly)")
+          pytest-blender --blender-executable $(Get-Variable -Name BLENDER_EXECUTABLE -ValueOnly)
+          $PYTHON_BLENDER_EXECUTABLE = (pytest-blender --blender-executable "$(Get-Variable -Name BLENDER_EXECUTABLE -ValueOnly)")
           echo "PYTHON_BLENDER_EXECUTABLE: $PYTHON_BLENDER_EXECUTABLE"
-        #$(Get-Variable -Name $PYTHON_BLENDER_EXECUTABLE -ValueOnly) -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
+        #$(Get-Variable -Name $PYTBLENDER_EXECUTABLEHON_BLENDER_EXECUTABLE -ValueOnly) -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
         #echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
       - name: Unit tests
         if: runner.os != 'Windows'
@@ -144,7 +144,8 @@ jobs:
         env:
           BLENDER_EXECUTABLE: ${{ steps.install-dependencies-unix.outputs.blender-executable }}
       # TODO: integration tests on Windows?
-      - run: exit 1
+      - if: runner.os == 'Windows'
+        run: exit 1
 
   build-sdist:
     if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,9 @@ jobs:
           - platform: windows-latest
             pytest-version: '7.1.2'
             blender-version: '3.1.2'
-            python-version: '3.8'
+            # Using 3.10 in Windows due to PIP encoding errors:
+            # https://github.com/pypa/pip/issues/11066
+            python-version: '3.10'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python v${{ matrix.python-version }}
@@ -67,6 +69,7 @@ jobs:
             blender-*
             _blender-executable-path.txt
           key: ${{ runner.os }}-${{ matrix.blender-version }}
+      # Download Blender in Linux and MacOS
       - name: Download Blender ${{ matrix.blender-version }}
         if: |
           steps.cache-blender.outputs.cache-hit != 'true' &&
@@ -74,8 +77,11 @@ jobs:
         run: |
           python -m pip install --upgrade blender-downloader
           python -m pip list
-          echo "$(blender-downloader ${{ matrix.blender-version }} --extract --remove-compressed --print-blender-executable --quiet)" > _blender-executable-path.txt
+          echo "$(blender-downloader ${{ matrix.blender-version }} \
+          --extract --remove-compressed --print-blender-executable --quiet)" \
+          > _blender-executable-path.txt
           cat _blender-executable-path.txt
+      # Download Blender in Windows
       - name: Download Blender ${{ matrix.blender-version }}
         if: |
           steps.cache-blender.outputs.cache-hit != 'true' &&
@@ -94,12 +100,13 @@ jobs:
         id: install-dependencies
         run: |
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
-          pytest-blender
+          pytest-blender D:\a\pytest-blender\pytest-blender\blender-3.1.2-windows-x64\blender.exe
       - name: Unit tests
         run: BLENDER_EXECUTABLE="${{ steps.install-dependencies.outputs.blender-executable }}" pytest -svv --strict-config --strict-markers tests
       - name: Integration tests
         run: BLENDER_EXECUTABLE="${{ steps.install-dependencies.outputs.blender-executable }}" sh tests/integration.sh
       - run: exit 1
+
   build-sdist:
     if: startsWith(github.ref, 'refs/tags/')
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,8 @@ jobs:
           steps.cache-blender.outputs.cache-hit != 'true' &&
           runner.os != 'Windows'
         run: |
-          set -x
-          python -m pip install --upgrade blender-downloader
-          python -m pip list
+          set -xenv:
+          BLENDER_EXECUTABLE: ${{ steps.install-dependencies-unix.outputs.blender-executable }}
           printf "%s" "$(blender-downloader ${{ matrix.blender-version }} --extract --remove-compressed --print-blender-executable --quiet)" > _blender-executable-path.txt
           cat _blender-executable-path.txt
       # Download Blender on Windows
@@ -122,13 +121,21 @@ jobs:
         # echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
       - name: Unit tests
         if: runner.os != 'Windows'
-        run: BLENDER_EXECUTABLE="${{ steps.install-dependencies-unix.outputs.blender-executable }}" pytest -svv --strict-config --strict-markers tests
+        run: pytest -svv --strict-config --strict-markers tests
+        env:
+          BLENDER_EXECUTABLE: ${{ steps.install-dependencies-unix.outputs.blender-executable }}
       - name: Unit tests
         if: runner.os == 'Windows'
-        run: pwsh -Command { $env:BLENDER_EXECUTABLE="${{ steps.install-dependencies-windows.outputs.blender-executable }}"; pytest -svv --strict-config --strict-markers tests }
+        run: pytest -svv --strict-config --strict-markers tests
+        env:
+          BLENDER_EXECUTABLE: ${{ steps.install-dependencies-windows.outputs.blender-executable }}
+          # https://github.com/pytest-dev/pytest/issues/4441
+          PYTHONIOENCODING: utf-8
       - name: Integration tests
         if: runner.os != 'Windows'
-        run: BLENDER_EXECUTABLE="${{ steps.install-dependencies-unix.outputs.blender-executable }}" sh tests/integration.sh
+        run: sh tests/integration.sh
+        env:
+          BLENDER_EXECUTABLE: ${{ steps.install-dependencies-unix.outputs.blender-executable }}
       # TODO: integration tests on Windows?
       - run: exit 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
           pytest-blender --blender-executable $(Get-Variable -Name BLENDER_EXECUTABLE)
           $PYTHON_BLENDER_EXECUTABLE = pytest-blender --blender-executable "$(Get-Variable -Name BLENDER_EXECUTABLE)"
           echo "PYTHON_BLENDER_EXECUTABLE: $PYTHON_BLENDER_EXECUTABLE"
-          $(Get-Variable -Name PYTHON_BLENDER_EXECUTABLE) -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
+          Invoke-Expression $PYTHON_BLENDER_EXECUTABLE -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
           echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
       - name: Unit tests
         if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,18 +70,16 @@ jobs:
       - name: Download Blender ${{ matrix.blender-version }}
         if: |
           steps.cache-blender.outputs.cache-hit != 'true' &&
-          ${{ matrix.platform != 'windows-latest' }}
+          ${{ matrix.platform }} != 'windows-latest'
         run: |
           python -m pip install --upgrade blender-downloader
           python -m pip list
-          echo "$(blender-downloader ${{ matrix.blender-version }} \
-          --extract --remove-compressed --print-blender-executable \
-          --quiet)" > _blender-executable-path.txt
+          echo "$(blender-downloader ${{ matrix.blender-version }} --extract --remove-compressed --print-blender-executable --quiet)" > _blender-executable-path.txt
           cat _blender-executable-path.txt
       - name: Download Blender ${{ matrix.blender-version }}
         if: |
           steps.cache-blender.outputs.cache-hit != 'true' &&
-          ${{ matrix.platform == 'windows-latest' }}
+          ${{ matrix.platform }} == 'windows-latest'
         run: |
           python -m pip install --upgrade blender-downloader
           python -m pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,9 @@ jobs:
           steps.cache-blender.outputs.cache-hit != 'true' &&
           runner.os != 'Windows'
         run: |
-          set -xenv:
-          BLENDER_EXECUTABLE: ${{ steps.install-dependencies-unix.outputs.blender-executable }}
+          set -x
+          python -m pip install --upgrade blender-downloader
+          python -m pip list
           printf "%s" "$(blender-downloader ${{ matrix.blender-version }} --extract --remove-compressed --print-blender-executable --quiet)" > _blender-executable-path.txt
           cat _blender-executable-path.txt
       # Download Blender on Windows
@@ -126,11 +127,14 @@ jobs:
           BLENDER_EXECUTABLE: ${{ steps.install-dependencies-unix.outputs.blender-executable }}
       - name: Unit tests
         if: runner.os == 'Windows'
-        run: pytest -svv --strict-config --strict-markers tests
+        # Created empty pytest.ini file to avoid the reading of setup.cfg
+        # because there is a problem with encoding on Windows, see:
+        # https://github.com/pytest-dev/pytest/issues/4441
+        run: |
+          New-Item -Path 'pytest.ini' -ItemType File
+          pytest -svv -p no:pytest-blender -p pytester --strict-config --strict-markers tests
         env:
           BLENDER_EXECUTABLE: ${{ steps.install-dependencies-windows.outputs.blender-executable }}
-          # https://github.com/pytest-dev/pytest/issues/4441
-          PYTHONIOENCODING: utf-8
       - name: Integration tests
         if: runner.os != 'Windows'
         run: sh tests/integration.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,20 +95,25 @@ jobs:
         run: |
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
           BLENDER_EXECUTABLE="$(< _blender-executable-path.txt)"
-          echo $BLENDER_EXECUTABLE
-          pytest-blender --blender-executable $BLENDER_EXECUTABLE
-          PYTHON_BLENDER_EXECUTABLE="$(pytest-blender --blender-executable $blender_executable)"
+          echo "$BLENDER_EXECUTABLE"
+          pytest-blender --blender-executable "$BLENDER_EXECUTABLE"
+          PYTHON_BLENDER_EXECUTABLE="$(pytest-blender --blender-executable $BLENDER_EXECUTABLE)"
+          echo "$PYTHON_BLENDER_EXECUTABLE"
           $PYTHON_BLENDER_EXECUTABLE -m ensurepip
           $PYTHON_BLENDER_EXECUTABLE -m pip install pytest==${{ matrix.pytest-version }}
-          echo "::set-output name=blender-executable::$blender_executable"
+          echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
       # Install dependencies on Windows
       - name: Install dependencies
         if: runner.os == 'Windows'
         run: |
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
           $BLENDER_EXECUTABLE = Get-Content _blender-executable-path.txt | Out-String
-          pytest-blender --blender-executable $BLENDER_EXECUTABLE
-
+          echo "$BLENDER_EXECUTABLE"
+          pytest-blender --blender-executable "$BLENDER_EXECUTABLE"
+          $PYTHON_BLENDER_EXECUTABLE = (pytest-blender --blender-executable "$BLENDER_EXECUTABLE")
+          echo "$PYTHON_BLENDER_EXECUTABLE"
+          $PYTHON_BLENDER_EXECUTABLE -m pip install pytest==${{ matrix.pytest-version }}
+          echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
       - name: Unit tests
         if: runner.os != 'Windows'
         run: BLENDER_EXECUTABLE="${{ steps.install-dependencies.outputs.blender-executable }}" pytest -svv --strict-config --strict-markers tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade PIP
-        run: python -m pip install --upgrade pip
+        run: python -m pip installplatform --upgrade pip
       - name: Cache Blender ${{ matrix.blender-version }}
         uses: actions/cache@v3
         id: cache-blender
@@ -68,27 +68,40 @@ jobs:
             _blender-executable-path.txt
           key: ${{ runner.os }}-${{ matrix.blender-version }}
       - name: Download Blender ${{ matrix.blender-version }}
-        if: steps.cache-blender.outputs.cache-hit != 'true'
-        id: download-blender
+        if: |
+          steps.cache-blender.outputs.cache-hit != 'true' &&
+          ${{ matrix.platform != 'windows-latest' }}
         run: |
           python -m pip install --upgrade blender-downloader
           python -m pip list
-          echo "$(blender-downloader ${{ matrix.blender-version }} --extract --remove-compressed --print-blender-executable --quiet)" > _blender-executable-path.txt
+          echo "$(blender-downloader ${{ matrix.blender-version }} \
+          --extract --remove-compressed --print-blender-executable \
+          --quiet)" > _blender-executable-path.txt
+          cat _blender-executable-path.txt
+      - name: Download Blender ${{ matrix.blender-version }}
+        if: |
+          steps.cache-blender.outputs.cache-hit != 'true' &&
+          ${{ matrix.platform == 'windows-latest' }}
+        run: |
+          python -m pip install --upgrade blender-downloader
+          python -m pip list
+          blender-downloader ${{ matrix.blender-version }} --extract --remove-compressed --print-blender-executable --quiet | Out-File -FilePath _blender-executable-path.txt
+          get-content _blender-executable-path.txt
+      #blender_executable="$(< _blender-executable-path.txt tr -d '\n')"
+      #python_blender_executable="$(pytest-blender --blender-executable $blender_executable)"
+      #$python_blender_executable -m ensurepip
+      #$python_blender_executable -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
+      #echo "::set-output name=blender-executable::$blender_executable"
       - name: Install dependencies
         id: install-dependencies
         run: |
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
           pytest-blender
-          blender_executable="$(< _blender-executable-path.txt tr -d '\n')"
-          python_blender_executable="$(pytest-blender --blender-executable $blender_executable)"
-          $python_blender_executable -m ensurepip
-          $python_blender_executable -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
-          echo "::set-output name=blender-executable::$blender_executable"
       - name: Unit tests
         run: BLENDER_EXECUTABLE="${{ steps.install-dependencies.outputs.blender-executable }}" pytest -svv --strict-config --strict-markers tests
       - name: Integration tests
         run: BLENDER_EXECUTABLE="${{ steps.install-dependencies.outputs.blender-executable }}" sh tests/integration.sh
-
+      - run: exit 1
   build-sdist:
     if: startsWith(github.ref, 'refs/tags/')
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,8 @@ jobs:
           pytest-blender --blender-executable $(Get-Variable -Name $BLENDER_EXECUTABLE -ValueOnly)
           $PYTHON_BLENDER_EXECUTABLE = (pytest-blender --blender-executable "$(Get-Variable -Name $BLENDER_EXECUTABLE -ValueOnly)")
           echo "PYTHON_BLENDER_EXECUTABLE: $PYTHON_BLENDER_EXECUTABLE"
-          $(Get-Variable -Name $PYTHON_BLENDER_EXECUTABLE -ValueOnly) -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
-          echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
+        #$(Get-Variable -Name $PYTHON_BLENDER_EXECUTABLE -ValueOnly) -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
+        #echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
       - name: Unit tests
         if: runner.os != 'Windows'
         run: pytest -svv --strict-config --strict-markers tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Download Blender ${{ matrix.blender-version }}
         if: |
           steps.cache-blender.outputs.cache-hit != 'true' &&
-          ${{ matrix.platform }} != 'windows-latest'
+          runner.os != 'Windows'
         run: |
           python -m pip install --upgrade blender-downloader
           python -m pip list
@@ -85,19 +85,27 @@ jobs:
       - name: Download Blender ${{ matrix.blender-version }}
         if: |
           steps.cache-blender.outputs.cache-hit != 'true' &&
-          ${{ matrix.platform }} == 'windows-latest'
+          runner.os == 'Windows'
         run: |
           python -m pip install --upgrade blender-downloader
           python -m pip list
           blender-downloader ${{ matrix.blender-version }} --extract --remove-compressed --print-blender-executable --quiet | Out-File -FilePath _blender-executable-path.txt
           get-content _blender-executable-path.txt
-      #blender_executable="$(< _blender-executable-path.txt tr -d '\n')"
-      #python_blender_executable="$(pytest-blender --blender-executable $blender_executable)"
-      #$python_blender_executable -m ensurepip
-      #$python_blender_executable -m pip install pytest==${{ matrix.pytest-version }} pytest-cov
-      #echo "::set-output name=blender-executable::$blender_executable"
+      # Install dependencies on Unix-based systems
       - name: Install dependencies
-        id: install-dependencies
+        if: runner.os != 'Windows'
+        run: |
+          python -m pip install .[test] pytest==${{ matrix.pytest-version }}
+          BLENDER_EXECUTABLE="$(< _blender-executable-path.txt tr -d '\n')"
+          echo $BLENDER_EXECUTABLE
+          pytest-blender --blender-executable $BLENDER_EXECUTABLE
+          PYTHON_BLENDER_EXECUTABLE="$(pytest-blender --blender-executable $blender_executable)"
+          $PYTHON_BLENDER_EXECUTABLE -m ensurepip
+          $PYTHON_BLENDER_EXECUTABLE -m pip install pytest==${{ matrix.pytest-version }}
+          echo "::set-output name=blender-executable::$blender_executable"
+      # Install dependencies on Windows
+      - name: Install dependencies
+        if: runner.os == 'Windows'
         run: |
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
           pytest-blender D:\a\pytest-blender\pytest-blender\blender-3.1.2-windows-x64\blender.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,7 @@ jobs:
         run: |
           python -m pip install --upgrade blender-downloader
           python -m pip list
-          echo "$(blender-downloader ${{ matrix.blender-version }} \
-          --extract --remove-compressed --print-blender-executable --quiet)" \
-          > _blender-executable-path.txt
+          printf "%s" "$(blender-downloader ${{ matrix.blender-version }} --extract --remove-compressed --print-blender-executable --quiet)" > _blender-executable-path.txt
           cat _blender-executable-path.txt
       # Download Blender on Windows
       - name: Download Blender ${{ matrix.blender-version }}
@@ -96,7 +94,7 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
-          BLENDER_EXECUTABLE="$(< _blender-executable-path.txt tr -d '\n')"
+          BLENDER_EXECUTABLE="$(< _blender-executable-path.txt)"
           echo $BLENDER_EXECUTABLE
           pytest-blender --blender-executable $BLENDER_EXECUTABLE
           PYTHON_BLENDER_EXECUTABLE="$(pytest-blender --blender-executable $blender_executable)"
@@ -108,7 +106,8 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
-          pytest-blender --blender-executable D:\a\pytest-blender\pytest-blender\blender-3.1.2-windows-x64\blender.exe
+          $BLENDER_EXECUTABLE = Get-Content _blender-executable-path.txt | Out-String
+          pytest-blender --blender-executable $BLENDER_EXECUTABLE
 
       - name: Unit tests
         if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       # Install dependencies on Unix-based systems
       - name: Install dependencies
         if: runner.os != 'Windows'
-        id: install-dependencies
+        id: install-dependencies-unix
         run: |
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
           BLENDER_EXECUTABLE="$(< _blender-executable-path.txt)"
@@ -106,7 +106,7 @@ jobs:
       # Install dependencies on Windows
       - name: Install dependencies
         if: runner.os == 'Windows'
-        id: install-dependencies
+        id: install-dependencies-windows
         run: |
           python -m pip install .[test] pytest==${{ matrix.pytest-version }}
           $BLENDER_EXECUTABLE = get-content _blender-executable-path.txt
@@ -118,13 +118,13 @@ jobs:
           echo "::set-output name=blender-executable::$BLENDER_EXECUTABLE"
       - name: Unit tests
         if: runner.os != 'Windows'
-        run: BLENDER_EXECUTABLE="${{ steps.install-dependencies.outputs.blender-executable }}" pytest -svv --strict-config --strict-markers tests
+        run: BLENDER_EXECUTABLE="${{ steps.install-dependencies-unix.outputs.blender-executable }}" pytest -svv --strict-config --strict-markers tests
       - name: Unit tests
         if: runner.os == 'Windows'
-        run: pwsh -Command { $env:BLENDER_EXECUTABLE="${{ steps.install-dependencies.outputs.blender-executable }}"; pytest -svv --strict-config --strict-markers tests }
+        run: pwsh -Command { $env:BLENDER_EXECUTABLE="${{ steps.install-dependencies-windows.outputs.blender-executable }}"; pytest -svv --strict-config --strict-markers tests }
       - name: Integration tests
         if: runner.os != 'Windows'
-        run: BLENDER_EXECUTABLE="${{ steps.install-dependencies.outputs.blender-executable }}" sh tests/integration.sh
+        run: BLENDER_EXECUTABLE="${{ steps.install-dependencies-unix.outputs.blender-executable }}" sh tests/integration.sh
       # TODO: integration tests on Windows?
       - run: exit 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
         id: download-blender
         run: |
           python -m pip install --upgrade blender-downloader
+          python -m pip list
           echo "$(blender-downloader ${{ matrix.blender-version }} --extract --remove-compressed --print-blender-executable --quiet)" > _blender-executable-path.txt
       - name: Install dependencies
         id: install-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,6 @@ jobs:
         env:
           BLENDER_EXECUTABLE: ${{ steps.install-dependencies-unix.outputs.blender-executable }}
       # TODO: integration tests on Windows?
-      - if: runner.os == 'Windows'
-        run: exit 1
 
   build-sdist:
     if: startsWith(github.ref, 'refs/tags/')

--- a/README.md
+++ b/README.md
@@ -349,7 +349,8 @@ pytest -svv --blender-executable ~/blender -- --debug
 
 You can use [blender-downloader] to download multiple
 versions of Blender in your CI and test against them. There is an example
-for Github Actions in the CI configuration of this repository:
+for Github Actions in the CI configuration of this repository, something
+like:
 
 ```yaml
 jobs:
@@ -386,14 +387,14 @@ jobs:
         id: download-blender
         run: |
           python -m pip install --upgrade blender-downloader
-          echo "$(blender-downloader \
+          printf "%s" "$(blender-downloader \
           ${{ matrix.blender-version }} --extract --remove-compressed \
           --quiet --print-blender-executable)" > _blender-executable-path.txt
       - name: Install dependencies
         id: install-dependencies
         run: |
           python -m pip install .[test]
-          blender_executable="$(< _blender-executable-path.txt tr -d '\n')"
+          blender_executable="$(< _blender-executable-path.txt)"
           python_blender_executable="$(pytest-blender --blender-executable $blender_executable)"
           $python_blender_executable -m ensurepip
           $python_blender_executable -m pip install pytest

--- a/pytest_blender/__init__.py
+++ b/pytest_blender/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.1"
+__version__ = "3.0.2"
 
 from pytest_blender.utils import (
     get_addons_dir,

--- a/pytest_blender/plugin.py
+++ b/pytest_blender/plugin.py
@@ -187,7 +187,8 @@ def pytest_configure(config):
             handled_exit()
 
         signal.signal(signal.SIGINT, on_sigint)
-        signal.signal(signal.SIGHUP, on_sigint)
+        if sys.platform != "windows":
+            signal.signal(signal.SIGHUP, on_sigint)
         signal.signal(signal.SIGTERM, on_sigint)
         proc.communicate()
 

--- a/pytest_blender/plugin.py
+++ b/pytest_blender/plugin.py
@@ -187,7 +187,7 @@ def pytest_configure(config):
             handled_exit()
 
         signal.signal(signal.SIGINT, on_sigint)
-        if sys.platform != "windows":
+        if "win" not in sys.platform:
             signal.signal(signal.SIGHUP, on_sigint)
         signal.signal(signal.SIGTERM, on_sigint)
         proc.communicate()

--- a/pytest_blender/utils.py
+++ b/pytest_blender/utils.py
@@ -97,6 +97,8 @@ def get_blender_binary_path_python(blender_executable, blend_version=None):
         stderr=subprocess.STDOUT,
     )
 
+    print(stdout.decode("utf-8").splitlines())
+
     blender_python_path = None
     for line in stdout.decode("utf-8").splitlines():
         if line.startswith(os.sep) and os.path.exists(line):

--- a/pytest_blender/utils.py
+++ b/pytest_blender/utils.py
@@ -97,11 +97,14 @@ def get_blender_binary_path_python(blender_executable, blend_version=None):
         stderr=subprocess.STDOUT,
     )
 
-    print(stdout.decode("utf-8").splitlines())
-
     blender_python_path = None
     for line in stdout.decode("utf-8").splitlines():
-        if line.startswith(os.sep) and os.path.exists(line):
+        # this should be enough to support Windows and Unix based systems
+        if (
+            os.path.exists(line)
+            and not os.path.isdir(line)
+            and "py" in os.path.basename(line.lower())
+        ):
             blender_python_path = line
             break
     return blender_python_path

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pytest_blender
-version = 3.0.1
+version = 3.0.2
 description = Blender Pytest plugin.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,13 +10,6 @@ import tempfile
 import pytest
 
 
-if sys.platform == "windows" and "CI" in os.environ:
-    # https://github.com/pytest-dev/pytest/issues/4441
-    import _locale
-
-    _locale._getdefaultlocale = lambda *args: ["en_US", "utf8"]
-
-
 TESTS_DIR = os.path.abspath(os.path.dirname(__file__))
 if TESTS_DIR not in sys.path:
     sys.path.append(TESTS_DIR)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,13 @@ import tempfile
 import pytest
 
 
+if sys.platform == "windows" and "CI" in os.environ:
+    # https://github.com/pytest-dev/pytest/issues/4441
+    import _locale
+
+    _locale._getdefaultlocale = lambda *args: ["en_US", "utf8"]
+
+
 TESTS_DIR = os.path.abspath(os.path.dirname(__file__))
 if TESTS_DIR not in sys.path:
     sys.path.append(TESTS_DIR)

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -30,7 +30,7 @@ def test_coverage_with_pytest_cov(testing_context):
             if not _inside_coverage:
                 if "coverage:" in line:
                     _inside_coverage = True
-            elif line.startswith("my_foo_library/functions.py"):
+            elif "functions.py" in line:
                 functions_mod_cov_line = line
 
         msg = f"{stdout}\n----\n{stderr}"

--- a/tests/test_functionality_fixtures.py
+++ b/tests/test_functionality_fixtures.py
@@ -39,8 +39,8 @@ def install_addons(install_addons_from_dir, uninstall_addons):
             ),
         },
     ) as ctx:
-        _, stderr, exitcode = ctx.run()
-        assert exitcode == 0, stderr
+        stdout, stderr, exitcode = ctx.run()
+        assert exitcode == 0, f"{stdout}\n---\n{stderr}"
 
     assert "pytest_blender_zipped" not in os.listdir(BLENDER_USER_ADDONS_DIR)
     assert "pytest_blender_zipped_from_dir" not in os.listdir(BLENDER_USER_ADDONS_DIR)

--- a/tests/test_functionality_fixtures.py
+++ b/tests/test_functionality_fixtures.py
@@ -92,7 +92,7 @@ def install_addons(install_addons_from_dir, uninstall_addons):
         assert (
             "[pytest-blender]"
             " Skipping installation of module 'helpers' as is not a"
-            " Blender addon (missing 'bl_info' module attribute)\n"
+            " Blender addon (missing 'bl_info' module attribute)"
         ) in stdout
 
     assert "pytest_blender_zipped" not in os.listdir(BLENDER_USER_ADDONS_DIR)

--- a/tests/test_functionality_fixtures.py
+++ b/tests/test_functionality_fixtures.py
@@ -16,6 +16,9 @@ FOO_ADDONS_DIR = os.path.join(ADDONS_DIRS, "foo")
 def test_install_addons_from_dir_fixture(testing_context):
     clean_addons()
 
+    # escape backslashes for Windows
+    escaped_addons_dir = FOO_ADDONS_DIR.replace("\\", "\\\\")
+
     with testing_context(
         empty_inicfg=True,
         files={
@@ -25,7 +28,7 @@ import pytest
 @pytest.fixture(scope="session", autouse=True)
 def install_addons(install_addons_from_dir, uninstall_addons):
     addons_ids = install_addons_from_dir(
-        "{FOO_ADDONS_DIR}",
+        "{escaped_addons_dir}",
         addons_ids=['pytest_blender_zipped'],
     )
     yield

--- a/tests/test_options/test_blender_executable_option.py
+++ b/tests/test_options/test_blender_executable_option.py
@@ -41,8 +41,8 @@ def test_blender_executable_cli_option_exists(testing_context):
             "tests/test_blender_executable.py": blender_executable_test,
         },
     ) as ctx:
-        _, stderr, exitcode = ctx.run(["--blender-executable", blender_executable])
-        assert exitcode == 0, stderr
+        stdout, stderr, exitcode = ctx.run(["--blender-executable", blender_executable])
+        assert exitcode == 0, f"{stdout}\n---\n{stderr}"
 
 
 def test_blender_executable_inicfg_option_not_exists(testing_context):
@@ -72,5 +72,5 @@ def test_blender_executable_inicfg_option_exists(testing_context):
             "pytest.ini": (f"[pytest]\nblender-executable = {blender_executable}\n"),
         },
     ) as ctx:
-        _, stderr, exitcode = ctx.run()
-        assert exitcode == 0, stderr
+        stdout, stderr, exitcode = ctx.run()
+        assert exitcode == 0, f"{stdout}\n---\n{stderr}"

--- a/tests/test_options/test_blender_executable_option.py
+++ b/tests/test_options/test_blender_executable_option.py
@@ -1,12 +1,12 @@
-from testing_utils import empty_test
-
-from pytest_blender import which_blender
+from testing_utils import blender_executable, empty_test
 
 
-blender_executable = which_blender()
+# escape backslashes for Windows
+escaped_blender_executable = blender_executable.replace("\\", "\\\\")
+
 blender_executable_test = f"""
 def test_blender_executable(blender_executable):
-    assert blender_executable == "{blender_executable}"
+    assert blender_executable == "{escaped_blender_executable}"
 """
 
 

--- a/tests/test_options/test_blender_executable_option.py
+++ b/tests/test_options/test_blender_executable_option.py
@@ -25,7 +25,13 @@ def test_blender_executable_cli_option_not_exists(testing_context):
             ]
         )
         assert exitcode == 3, stderr
-        assert "No such file or directory: 'foobarbazimpossibletoexist'" in stderr
+        assert (
+            # unix
+            "No such file or directory: 'foobarbazimpossibletoexist'" in stderr
+            or
+            # windows
+            "The system cannot find the file specified" in stderr
+        )
 
 
 def test_blender_executable_cli_option_exists(testing_context):
@@ -50,7 +56,13 @@ def test_blender_executable_inicfg_option_not_exists(testing_context):
     ) as ctx:
         _, stderr, exitcode = ctx.run()
         assert exitcode == 3, stderr
-        assert "No such file or directory: 'foobarbazimpossibletoexist'" in stderr
+        assert (
+            # unix
+            "No such file or directory: 'foobarbazimpossibletoexist'" in stderr
+            or
+            # windows
+            "The system cannot find the file specified" in stderr
+        )
 
 
 def test_blender_executable_inicfg_option_exists(testing_context):


### PR DESCRIPTION
- Fix `pytest-blender` CLI outputting `None` on Windows.
- Fix error handling signals on Windows.
 
Resolves #68 