### PR TITLE
require pytest by default

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,8 @@ project_urls =
 [options]
 packages = pytest_blender
 python_requires = >=3.7
+install_requires =
+    pytest
 
 [options.entry_points]
 console_scripts =
@@ -39,10 +41,8 @@ pytest11 =
 
 [options.extras_require]
 dev =
-    pytest
     pytest-cov
 test =
-    pytest
     pytest-cov
 
 [tool:pytest]


### PR DESCRIPTION
Probably very minor but noticed that just installing `pytest-blender` doesn't install `pytest` though it seems to be required.