### PR TITLE
Allow `blender` to also be `blender.bat` on Windows #95

### DIFF
--- a/pytest_blender/utils.py
+++ b/pytest_blender/utils.py
@@ -51,7 +51,7 @@ def which_blender():
     return (
         shutil.which("Blender")
         if sys.platform == "darwin"
-        else ("blender.exe" if "win" in sys.platform else shutil.which("blender"))
+        else shutil.which("blender")
     )
 
 


### PR DESCRIPTION
See more details in #95