### PR TITLE
Fix: Handle End of Options ('--') correctly to avoid "unrecognized arguments" error (fix #99)

### DIFF
--- a/pytest_blender/plugin.py
+++ b/pytest_blender/plugin.py
@@ -81,6 +81,16 @@ def get_pytest_blender_debug(config):
 
 
 @pytest.hookimpl(tryfirst=True)
+def pytest_load_initial_conftests(early_config, parser, args):
+    # Strip arguments after '--' to prevent Pytest from treating them as 'file_or_dir'.
+    if "--" not in args:
+        return
+
+    idx = args.index("--")
+    del args[idx + 1 :]
+
+
+@pytest.hookimpl(tryfirst=True)
 def pytest_addoption(parser):
     for arg, argdef in OPTIONS.items():
         kwargs = argdef["opts"] if "opts" in argdef else {"default": None}
@@ -169,8 +179,7 @@ def pytest_configure(config):
 
     if pytest_blender_debug:
         sys.stdout.write(
-            "[DEBUG (pytest-blender)] Running blender with:"
-            f" {utils.shlex_join(args)}\n"
+            f"[DEBUG (pytest-blender)] Running blender with: {utils.shlex_join(args)}\n"
         )
 
     with subprocess.Popen(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,7 +89,7 @@ def testing_context():
                 if additional_blender_args is None:
                     additional_blender_args = []
                 else:
-                    additional_blender_args.insert(0, "--")
+                    additional_blender_args = ["--", *additional_blender_args]
 
                 cmd = [
                     *cmd_prefix,
@@ -100,6 +100,7 @@ def testing_context():
                     "--strict-markers",
                     "--strict-config",
                     *additional_pytest_args,
+                    *additional_blender_args,
                 ]
                 with subprocess.Popen(
                     cmd,

--- a/tests/test_blender_execution.py
+++ b/tests/test_blender_execution.py
@@ -1,7 +1,4 @@
-import copy
 import os
-import subprocess
-import sys
 
 from testing_utils import empty_test
 
@@ -25,7 +22,7 @@ def test_blender_argv():
         assert "argv[2] = --debug" in stdout, stderr
 
 
-def test_blender_cli_args_pass_through_with_separator(tmp_path):
+def test_blender_cli_args_pass_through_with_separator(testing_context):
     """
     Verify that pytest-blender correctly handles CLI arguments passed after the
     '--' (End of Options) separator.
@@ -34,88 +31,35 @@ def test_blender_cli_args_pass_through_with_separator(tmp_path):
     which are intended for Blender, are not mistakenly parsed by Pytest as positional
     file/directory arguments or unrecognized options when placed after '--'.
     """
-    # --- Test Environment Setup ---
-    rootdir = tmp_path / "blender_test_proj"
-    rootdir.mkdir()
-
-    # Create pytest.ini to enable pytest-blender configuration
-    ini = rootdir / "pytest.ini"
-    ini.write_text(
-        """
-[pytest]
-pytest-blender-debug=true
-"""
-    )
-
-    # Create tests directory and test file
-    tests_dir = rootdir / "tests"
-    tests_dir.mkdir()
-
-    test_file = tests_dir / "test_blender_integration.py"
-    test_file.write_text(
-        """
+    files = {
+        "pytest.ini": "[pytest]\npytest-blender-debug=true\n",
+        "tests/test_blender_integration.py": """
 def test_blender_env_check(pytestconfig):
-    '''
-    A simple placeholder test to ensure the session runs.
-    The primary verification happens in conftest and via CLI output checks.
-    '''
     import os
     assert os.path.exists(__file__)
-"""
-    )
-
-    # Create conftest.py for hook-based validation
-    conftest = tests_dir / "conftest.py"
-    conftest.write_text(
-        """
+""",
+        "tests/conftest.py": """
 import pytest
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_configure(config):
-    # Stage 1 check: Ensure '--' arguments are filtered out by Pytest.
-    # 'no:pytest-blender' is present only in Stage 2 (inside Blender),
-    # so its absence confirms Stage 1.
     if "no:pytest-blender" not in config.invocation_params.args:
-        assert [] == config.option.file_or_dir, \
-            ("Expected empty file_or_dir in Stage 1;"
-            " args after '--' were passed as plugin-specific arguments.")
-"""
-    )
+        assert [] == config.option.file_or_dir, (
+            "Expected empty file_or_dir in Stage 1;"
+            " args after '--' were passed as plugin-specific arguments."
+        )
+""",
+    }
 
-    # --- Command Execution ---
-    # Construct command with '--' to separate pytest options from Blender arguments
-    cmd = [
-        sys.executable,
-        "-m",
-        "pytest",
-        "-svv",  # Verbose output
-        "--",  # End of Options: Everything after this is treated as plugin-specific
-        "--python-use-system-env",  # Argument intended for Blender, not pytest
-    ]
+    with testing_context(files=files) as ctx:
+        stdout, stderr, exit_code = ctx.run(
+            additional_blender_args=["--python-use-system-env"],
+        )
 
-    # Prepare environment to ensure isolation from host system's PWD
-    env = copy.deepcopy(os.environ)
-    if "PWD" in env:
-        del env["PWD"]
-    env["PWD"] = str(rootdir)
-
-    result = subprocess.run(
-        cmd, capture_output=True, text=True, cwd=str(rootdir), env=env
-    )
-
-    stdout = result.stdout
-    stderr = result.stderr
-    exit_code = result.returncode
-
-    # --- Assertions ---
-
-    # Ensure the process exited successfully (exit code 0)
-    assert exit_code == 0, f"pytest failed to run successfully. STDERR:\\n{stderr}"
-
-    # CLI arguments propagate to blender_opts
+    assert exit_code == 0, f"pytest failed. STDERR:\n{stderr}"
     assert (
         "-b --python-use-system-env --python" in stdout
-    ), f"cli arguments propagation failed. STDOUT:\\n{stdout}"
+    ), f"cli arguments propagation failed. STDOUT:\n{stdout}"
 
 
 def test_cli_env_propagation(testing_context):

--- a/tests/test_blender_execution.py
+++ b/tests/test_blender_execution.py
@@ -40,17 +40,20 @@ def test_blender_cli_args_pass_through_with_separator(tmp_path):
 
     # Create pytest.ini to enable pytest-blender configuration
     ini = rootdir / "pytest.ini"
-    ini.write_text("""
+    ini.write_text(
+        """
 [pytest]
 pytest-blender-debug=true
-""")
+"""
+    )
 
     # Create tests directory and test file
     tests_dir = rootdir / "tests"
     tests_dir.mkdir()
 
     test_file = tests_dir / "test_blender_integration.py"
-    test_file.write_text("""
+    test_file.write_text(
+        """
 def test_blender_env_check(pytestconfig):
     '''
     A simple placeholder test to ensure the session runs.
@@ -58,21 +61,26 @@ def test_blender_env_check(pytestconfig):
     '''
     import os
     assert os.path.exists(__file__)
-""")
+"""
+    )
 
     # Create conftest.py for hook-based validation
     conftest = tests_dir / "conftest.py"
-    conftest.write_text("""
+    conftest.write_text(
+        """
 import pytest
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_configure(config):
     # Stage 1 check: Ensure '--' arguments are filtered out by Pytest.
-    # 'no:pytest-blender' is present only in Stage 2 (inside Blender), so its absence confirms Stage 1.
+    # 'no:pytest-blender' is present only in Stage 2 (inside Blender),
+    # so its absence confirms Stage 1.
     if "no:pytest-blender" not in config.invocation_params.args:
         assert [] == config.option.file_or_dir, \
-            "Expected empty file_or_dir in Stage 1; args after '--' were passed as plugin-specific arguments."
-""")
+            ("Expected empty file_or_dir in Stage 1;"
+            " args after '--' were passed as plugin-specific arguments.")
+"""
+    )
 
     # --- Command Execution ---
     # Construct command with '--' to separate pytest options from Blender arguments
@@ -91,8 +99,6 @@ def pytest_configure(config):
         del env["PWD"]
     env["PWD"] = str(rootdir)
 
-    print(f"Running command: {' '.join(cmd)}")
-
     result = subprocess.run(
         cmd, capture_output=True, text=True, cwd=str(rootdir), env=env
     )
@@ -104,17 +110,12 @@ def pytest_configure(config):
     # --- Assertions ---
 
     # Ensure the process exited successfully (exit code 0)
-    if exit_code != 0:
-        print(f"STDOUT:\n{stdout}")
-        print(f"STDERR:\n{stderr}")
-
     assert exit_code == 0, f"pytest failed to run successfully. STDERR:\\n{stderr}"
 
     # CLI arguments propagate to blender_opts
-    assert "-b --python-use-system-env --python" in stdout, (
-        f"cli arguments propagation failed. STDOUT:\\n{stdout}"
-    )
-    print(stdout, stderr)
+    assert (
+        "-b --python-use-system-env --python" in stdout
+    ), f"cli arguments propagation failed. STDOUT:\\n{stdout}"
 
 
 def test_cli_env_propagation(testing_context):

--- a/tests/test_blender_execution.py
+++ b/tests/test_blender_execution.py
@@ -1,4 +1,7 @@
+import copy
 import os
+import subprocess
+import sys
 
 from testing_utils import empty_test
 
@@ -20,6 +23,98 @@ def test_blender_argv():
 
         # Blender debugging information with `--debug`
         assert "argv[2] = --debug" in stdout, stderr
+
+
+def test_blender_cli_args_pass_through_with_separator(tmp_path):
+    """
+    Verify that pytest-blender correctly handles CLI arguments passed after the
+    '--' (End of Options) separator.
+
+    Specifically, this test ensures that arguments like '--python-use-system-env',
+    which are intended for Blender, are not mistakenly parsed by Pytest as positional
+    file/directory arguments or unrecognized options when placed after '--'.
+    """
+    # --- Test Environment Setup ---
+    rootdir = tmp_path / "blender_test_proj"
+    rootdir.mkdir()
+
+    # Create pytest.ini to enable pytest-blender configuration
+    ini = rootdir / "pytest.ini"
+    ini.write_text("""
+[pytest]
+pytest-blender-debug=true
+""")
+
+    # Create tests directory and test file
+    tests_dir = rootdir / "tests"
+    tests_dir.mkdir()
+
+    test_file = tests_dir / "test_blender_integration.py"
+    test_file.write_text("""
+def test_blender_env_check(pytestconfig):
+    '''
+    A simple placeholder test to ensure the session runs.
+    The primary verification happens in conftest and via CLI output checks.
+    '''
+    import os
+    assert os.path.exists(__file__)
+""")
+
+    # Create conftest.py for hook-based validation
+    conftest = tests_dir / "conftest.py"
+    conftest.write_text("""
+import pytest
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config):
+    # Stage 1 check: Ensure '--' arguments are filtered out by Pytest.
+    # 'no:pytest-blender' is present only in Stage 2 (inside Blender), so its absence confirms Stage 1.
+    if "no:pytest-blender" not in config.invocation_params.args:
+        assert [] == config.option.file_or_dir, \
+            "Expected empty file_or_dir in Stage 1; args after '--' were passed as plugin-specific arguments."
+""")
+
+    # --- Command Execution ---
+    # Construct command with '--' to separate pytest options from Blender arguments
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-svv",  # Verbose output
+        "--",  # End of Options: Everything after this is treated as plugin-specific
+        "--python-use-system-env",  # Argument intended for Blender, not pytest
+    ]
+
+    # Prepare environment to ensure isolation from host system's PWD
+    env = copy.deepcopy(os.environ)
+    if "PWD" in env:
+        del env["PWD"]
+    env["PWD"] = str(rootdir)
+
+    print(f"Running command: {' '.join(cmd)}")
+
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, cwd=str(rootdir), env=env
+    )
+
+    stdout = result.stdout
+    stderr = result.stderr
+    exit_code = result.returncode
+
+    # --- Assertions ---
+
+    # Ensure the process exited successfully (exit code 0)
+    if exit_code != 0:
+        print(f"STDOUT:\n{stdout}")
+        print(f"STDERR:\n{stderr}")
+
+    assert exit_code == 0, f"pytest failed to run successfully. STDERR:\\n{stderr}"
+
+    # CLI arguments propagate to blender_opts
+    assert "-b --python-use-system-env --python" in stdout, (
+        f"cli arguments propagation failed. STDOUT:\\n{stdout}"
+    )
+    print(stdout, stderr)
 
 
 def test_cli_env_propagation(testing_context):


### PR DESCRIPTION
#### Problem
When running tests with `pytest-blender`, passing arguments intended for Blender via the command line separator `--` (e.g., `pytest -- --python-use-system-env`) resulted in the following error: (fix #99)

```text
ERROR: usage: pytest [options] [file_or_dir] [...]
pytest: error: unrecognized arguments: --python-use-system-env
```

**Root Cause:**
Pytest parses CLI arguments before plugins fully take over. When `--` is encountered, Pytest treats everything after it as a positional argument (`file_or_dir`). Since `--python-use-system-env` is not a valid file path or directory name for the initial Pytest run (Stage 1), it throws an "unrecognized arguments" error before `pytest-blender` can intercept and forward them to the Blender process (Stage 2).

#### Solution
This PR introduces a fix in the `pytest_load_initial_conftests` hook. We now explicitly detect the presence of `--` in the argument list during the initial configuration phase and strip all arguments following it from Pytest's internal argument list (`args`).

**Changes:**
- Added logic in `pytest_load_initial_conftests` to check for `--`.
- If found, truncate the `args` list at the index of `--`, removing subsequent elements.
- This ensures Pytest only sees valid options and paths during Stage 1, preventing the parsing error while allowing the plugin to handle the trailing arguments correctly in Stage 2 (or via other mechanisms).
